### PR TITLE
Pour l'issues #7 Déroulement des menus trop rapide sur mobile

### DIFF
--- a/templates/m6r/categories.tpl
+++ b/templates/m6r/categories.tpl
@@ -8,21 +8,43 @@
 			{checkActionsTpl location="tpl_widget_categories_start"}
 			{section name=thecat loop=$cat_array}
 				{if $cat_array[thecat].auto_id neq 0}
-					{if $cat_array[thecat].spacercount < $submit_lastspacer}
-						{$cat_array[thecat].spacerdiff|repeat_count:'</ul></li>'}
-					{/if}
-					{if $cat_array[thecat].spacercount > $submit_lastspacer}
-						<ul class="dropdown-menu {if $cat_array[thecat].principlecat eq 0}sub-menu{/if} sub-menu-show sub-menu-hide">
-					{/if}
-					<li class="category_item{if $cat_array[thecat].principlecat neq 0} dropdown{/if}{if $request_category eq $cat_array[thecat].safename} active{/if}">
-						<a {if $cat_array[thecat].principlecat neq 0} class="dropdown-toggle active"{/if} href="{if $pagename eq "new" || $groupview eq "new"}{$URL_newcategory, $cat_array[thecat].safename}{else}{$URL_maincategory, $cat_array[thecat].safename}{/if}{if $urlmethod==2}/{/if}">{$cat_array[thecat].name} {if $cat_array[thecat].principlecat neq 0}<b class="caret"></b>{/if}</a>
-					{if $cat_array[thecat].principlecat eq 0}
-						</li>
-					{/if}
-					{assign var=submit_lastspacer value=$cat_array[thecat].spacercount}
+                                    {if $cat_array[thecat].parent eq 0}
+                                        {if $cat_array[thecat].principlecat neq 0}
+                                            <div class="btn-group">
+                                                <button type="button" class="btn btn-primary">
+                                                    <a href="{if $pagename eq "new" || $groupview eq "new"}{$URL_newcategory, $cat_array[thecat].safename}{else}{$URL_maincategory, $cat_array[thecat].safename}{/if}{if $urlmethod==2}/{/if}">{$cat_array[thecat].name}</a>
+                                                </button>
+                                                <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                                                    <span class="caret"></span>
+                                                    <span class="sr-only">Toggle Dropdown</span>
+                                                </button>
+                                        {else}
+                                            <button type="button" class="btn btn-primary">
+                                                <a href="{if $pagename eq "new" || $groupview eq "new"}{$URL_newcategory, $cat_array[thecat].safename}{else}{$URL_maincategory, $cat_array[thecat].safename}{/if}{if $urlmethod==2}/{/if}">{$cat_array[thecat].name}</a>
+                                            </button>
+                                        {/if}
+                                     {/if}
+                                    {if $cat_array[thecat].parent neq 0}
+                                        {if $cat_array[thecat].spacercount < $submit_lastspacer}
+                                                {$cat_array[thecat].spacerdiff|repeat_count:'</ul></li>'}
+                                        {/if}
+                                        {if $cat_array[thecat].spacercount > $submit_lastspacer}
+                                                <ul class="dropdown-menu {if $cat_array[thecat].principlecat eq 0}sub-menu{/if} sub-menu-show sub-menu-hide">
+                                        {/if}
+                                        <li class="category_item{if $cat_array[thecat].principlecat neq 0} dropdown{/if}{if $request_category eq $cat_array[thecat].safename} active{/if}">
+                                                <a {if $cat_array[thecat].principlecat neq 0} class="dropdown-toggle active"{/if} href="{if $pagename eq "new" || $groupview eq "new"}{$URL_newcategory, $cat_array[thecat].safename}{else}{$URL_maincategory, $cat_array[thecat].safename}{/if}{if $urlmethod==2}/{/if}">{$cat_array[thecat].name} {if $cat_array[thecat].principlecat neq 0}<b class="caret"></b>{/if}</a>
+                                        {if $cat_array[thecat].principlecat eq 0}
+                                                </li>
+                                        {/if}
+                                        {assign var=submit_lastspacer value=$cat_array[thecat].spacercount}
+                                    {/if} 
 				{/if}
 			{/section}
-			{if $cat_array[thecat].spacercount < $submit_lastspacer}{$lastspacer|repeat_count:'</ul></li>'}{/if}
+			{if $cat_array[thecat].spacercount < $submit_lastspacer}
+                            {$lastspacer|repeat_count:'</ul></li>'}
+                            </ul>
+                        </div>
+                        {/if}
 			{checkActionsTpl location="tpl_widget_categories_end"}
 		</ul>
 	</div>


### PR DESCRIPTION
Remplacement des éléments de premier niveau de menu par des boutons et bouton dropdown .

Permets de voir les élément de deuxieme niveau tranquillement mais le problème persiste pour le déroulements des menus plus profond

Besoin de CSS ! ;-)